### PR TITLE
node 22.18.0 2025-07-31

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required(VERSION 3.31)
 set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES .devcontainer/cmake/xproinc.cmake)
-project(nodexp VERSION 20.18.0)
-# https://nodejs.org/dist/v20.18.0/SHASUMS256.txt
-set(SHA256_win64 f5cea43414cc33024bbe5867f208d1c9c915d6a38e92abeee07ed9e563662297) # node-v20.18.0-win-x64.zip
-set(SHA256_hders b9984e1fb92e30437cf41c1b9ae3361a87022aa2528f9b77d5e415d772d28d96) # node-v20.18.0-headers.tar.xz
-set(SHA256_ndlib afeae4c806b82987ee073c9c75a0e5c5530213145c64f2824d0ed220a6acf962) # win-x64/node.lib
-set(SHA256_Linux 4543670b589593f8fa5f106111fd5139081da42bb165a9239f05195e405f240a) # node-v20.18.0-linux-x64.tar.xz
-set(SHA256_arm64 a9ce85675ba33f00527f6234d90000946c0936fb4fca605f1891bb5f4fe6fb0a) # node-v20.18.0-linux-arm64.tar.xz
-set(SHA256_macos 678e062bdae3824aa997bd469580a4dda48fd51f61d3679b6ba06352e6cef38f) # node-v20.18.0-darwin-arm64.tar.xz
+project(nodexp VERSION 22.18.0)
+# https://nodejs.org/dist/v22.18.0/SHASUMS256.txt
+set(SHA256_win64 c95d8a7e1c99e669cc08c9f1176e068c1f50847c37908fcb8c35b62482366511) # node-v22.18.0-win-x64.zip
+set(SHA256_hders 68a214508678fc6119bf1ad391fbf89fb624ab000d85693ef7c8a764b6622351) # node-v22.18.0-headers.tar.xz
+set(SHA256_ndlib 4af0951712fb05a686a03e0592880e195ba53e5eb70e224d7ea7b8b76f2a3e86) # win-x64/node.lib
+set(SHA256_Linux c1bfeecf1d7404fa74728f9db72e697decbd8119ccc6f5a294d795756dfcfca7) # node-v22.18.0-linux-x64.tar.xz
+set(SHA256_arm64 04fca1b9afecf375f26b41d65d52aa1703a621abea5a8948c7d1e351e85edade) # node-v22.18.0-linux-arm64.tar.xz
+set(SHA256_macos 6616f388e127c858989fc7fa92879cdb20d2a5d446adbfdca6ee4feb385bfa8a) # node-v22.18.0-darwin-arm64.tar.xz
 include(xpflags)
 include(FetchContent)
 cmake_policy(SET CMP0168 OLD) # don't want to see download progress


### PR DESCRIPTION
* https://nodejs.org/en/blog/release/v22.18.0
* https://nodejs.org/dist/v22.18.0/SHASUMS256.txt
* issue https://github.com/externpro/externpro/issues/182